### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,3 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
+[troyhart/bloxlet-coral-config](https://github.com/troyhart/bloxlet-coral-config.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[troyhart/jx-spring1](https://github.com/troyhart/jx-spring1.git) |  | []() | 
+[troyhart/jx-spring2](https://github.com/troyhart/jx-spring2.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[troyhart/spring-demo4jx1](https://github.com/troyhart/spring-demo4jx1.git) |  | []() | 
+[troyhart/jx-spring1](https://github.com/troyhart/jx-spring1.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[troyhart/spring-demo4jx1](https://github.com/troyhart/spring-demo4jx1.git) |  | []() | 
+[troyhart/bloxlet-coral-config](https://github.com/troyhart/bloxlet-coral-config.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[troyhart/bloxlet-coral-config](https://github.com/troyhart/bloxlet-coral-config.git) |  | []() | 
+[troyhart/spring-demo4jx1](https://github.com/troyhart/spring-demo4jx1.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: troyhart
-  repo: spring-demo4jx1
-  url: https://github.com/troyhart/spring-demo4jx1.git
+  repo: bloxlet-coral-config
+  url: https://github.com/troyhart/bloxlet-coral-config.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: troyhart
-  repo: jx-spring1
-  url: https://github.com/troyhart/jx-spring1.git
+  repo: jx-spring2
+  url: https://github.com/troyhart/jx-spring2.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,1 +1,7 @@
 dependencies:
+- host: github.com
+  owner: troyhart
+  repo: bloxlet-coral-config
+  url: https://github.com/troyhart/bloxlet-coral-config.git
+  version: ""
+  versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: troyhart
-  repo: spring-demo4jx1
-  url: https://github.com/troyhart/spring-demo4jx1.git
+  repo: jx-spring1
+  url: https://github.com/troyhart/jx-spring1.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: troyhart
-  repo: bloxlet-coral-config
-  url: https://github.com/troyhart/bloxlet-coral-config.git
+  repo: spring-demo4jx1
+  url: https://github.com/troyhart/spring-demo4jx1.git
   version: ""
   versionURL: ""

--- a/repositories/templates/troyhart-bloxlet-coral-config-sr.yaml
+++ b/repositories/templates/troyhart-bloxlet-coral-config-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: troyhart
+    provider: github
+    repository: bloxlet-coral-config
+  name: troyhart-bloxlet-coral-config
+spec:
+  description: Imported application for troyhart/bloxlet-coral-config
+  httpCloneURL: https://github.com/troyhart/bloxlet-coral-config.git
+  org: troyhart
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: bloxlet-coral-config
+  scheduler:
+    kind: ""
+    name: ""
+  url: git@github.com:troyhart/bloxlet-coral-config.git

--- a/repositories/templates/troyhart-bloxlet-coral-config-sr.yaml
+++ b/repositories/templates/troyhart-bloxlet-coral-config-sr.yaml
@@ -2,7 +2,8 @@ apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
   annotations:
-    jenkins.io/last-build-number-for-master: "1"
+    jenkins.io/last-build-number-for-master: "2"
+    jenkins.io/last-build-number-for-pr-2: "2"
   creationTimestamp: null
   labels:
     owner: troyhart

--- a/repositories/templates/troyhart-bloxlet-coral-config-sr.yaml
+++ b/repositories/templates/troyhart-bloxlet-coral-config-sr.yaml
@@ -1,6 +1,8 @@
 apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
+  annotations:
+    jenkins.io/last-build-number-for-master: "1"
   creationTimestamp: null
   labels:
     owner: troyhart

--- a/repositories/templates/troyhart-jx-spring1-sr.yaml
+++ b/repositories/templates/troyhart-jx-spring1-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: troyhart
+    provider: github
+    repository: jx-spring1
+  name: troyhart-jx-spring1
+spec:
+  description: Imported application for troyhart/jx-spring1
+  httpCloneURL: https://github.com/troyhart/jx-spring1.git
+  org: troyhart
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-spring1
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/troyhart/jx-spring1.git

--- a/repositories/templates/troyhart-jx-spring2-sr.yaml
+++ b/repositories/templates/troyhart-jx-spring2-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: troyhart
+    provider: github
+    repository: jx-spring2
+  name: troyhart-jx-spring2
+spec:
+  description: Imported application for troyhart/jx-spring2
+  httpCloneURL: https://github.com/troyhart/jx-spring2.git
+  org: troyhart
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-spring2
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/troyhart/jx-spring2.git

--- a/repositories/templates/troyhart-spring-demo4jx1-sr.yaml
+++ b/repositories/templates/troyhart-spring-demo4jx1-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: troyhart
+    provider: github
+    repository: spring-demo4jx1
+  name: troyhart-spring-demo4jx1
+spec:
+  description: Imported application for troyhart/spring-demo4jx1
+  httpCloneURL: https://github.com/troyhart/spring-demo4jx1.git
+  org: troyhart
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: spring-demo4jx1
+  scheduler:
+    kind: ""
+    name: ""
+  url: git@github.com:troyhart/spring-demo4jx1.git


### PR DESCRIPTION
Update [troyhart/jx-spring2](https://github.com/troyhart/jx-spring2.git) 

Command run was `jx create spring`
<hr />

Update [troyhart/jx-spring1](https://github.com/troyhart/jx-spring1.git) 

Command run was `jx import`
<hr />

Update [troyhart/spring-demo4jx1](https://github.com/troyhart/spring-demo4jx1.git) 

Command run was `jx import`
<hr />

Update [troyhart/bloxlet-coral-config](https://github.com/troyhart/bloxlet-coral-config.git) 

Command run was `jx import`
<hr />

Update [troyhart/spring-demo4jx1](https://github.com/troyhart/spring-demo4jx1.git) 

Command run was `jx import`
<hr />

Update [troyhart/bloxlet-coral-config](https://github.com/troyhart/bloxlet-coral-config.git) 

Command run was `jx import`
<hr />

Update [troyhart/bloxlet-coral-config](https://github.com/troyhart/bloxlet-coral-config.git) 

Command run was `jx import`